### PR TITLE
Add API endpoint for creating paper cards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,11 @@ SERVICE_HOST=https://example.com
 # (optional)
 # Specify when you use OpenAI API.
 # OPENAI_API_KEY=12345
+
+# ------------------------------------------
+# API Keys section
+# ------------------------------------------
+# (optional)
+# Specify when you use via API endpoints.
+# API_BEARER_TOKEN=your_secure_token_here
+

--- a/app/controllers/api/v1/paper/cards_controller.rb
+++ b/app/controllers/api/v1/paper/cards_controller.rb
@@ -1,0 +1,27 @@
+class API::V1::Paper::CardsController < ApplicationController
+  before_action :authenticate_token
+  skip_before_action :verify_authenticity_token
+
+  def create
+    @paper_card = Paper::Card.new(paper_card_params)
+
+    if @paper_card.save
+      render json: { message: "Card was successfully created.", card: @paper_card }, status: :created
+    else
+      render json: { errors: @paper_card.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def authenticate_token
+    token = request.headers['Authorization']
+    if token != "Bearer #{ENV['API_BEARER_TOKEN']}"
+      render json: { error: 'Unauthorized' }, status: :unauthorized
+    end
+  end
+
+  def paper_card_params
+    params.require(:paper_card).permit(:image)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,9 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "paper/cards#index"
+  namespace :api do
+    namespace :v1 do
+      resources :paper_cards, only: [:create], controller: 'paper/cards'
+    end
+  end
 end


### PR DESCRIPTION
Introduced a new API endpoint under `/api/v1/paper_cards` for creating paper cards. Added token-based authentication using `API_BEARER_TOKEN` from the environment variables. Updated routes and `.env.example` to support the new functionality.

## Usage
To use the newly introduced API endpoint for creating paper cards, follow these steps:

### 1. Set up the environment
Make sure you have a valid API_BEARER_TOKEN in your environment variables. You can add it to your .env file like this:

```bash
API_BEARER_TOKEN=your_secure_token_here
```
Ensure your Rails server is running.

### 2. API Request Example

You can use curl to make a POST request to the /api/v1/paper_cards endpoint with an attached image. Make sure to include the Authorization header with the Bearer token.

```bash
curl -X POST "http://localhost:3000/api/v1/paper_cards" \
     -H "Authorization: Bearer your_secure_token_here" \
     -F "paper_card[image]=@/path/to/your_image.jpg"
```
### 3. Response Example
If the request is successful, you will receive a JSON response similar to this:

```json
{
  "message": "Card was successfully created.",
  "card": {
    "id": 1,
    "image_url": "http://localhost:3000/rails/active_storage/blobs/...",
    ...
  }
}
```
If the token is invalid or missing, you will receive an Unauthorized response:

```json
{
  "error": "Unauthorized"
}
```

I've written these instructions for using the API with curl. If you have any suggestions for improvement, I’d like to hear them!

